### PR TITLE
Support single touch event files

### DIFF
--- a/jni/minitouch/minitouch.c
+++ b/jni/minitouch/minitouch.c
@@ -83,6 +83,11 @@ static int is_multitouch_device(struct libevdev* evdev)
   return libevdev_has_event_code(evdev, EV_ABS, ABS_MT_POSITION_X);
 }
 
+static int is_singletouch_device(struct libevdev* evdev)
+{
+  return libevdev_has_event_code(evdev, EV_ABS, ABS_X);
+}
+
 static int consider_device(const char* devpath, internal_state_t* state)
 {
   int fd = -1;
@@ -106,12 +111,15 @@ static int consider_device(const char* devpath, internal_state_t* state)
     goto mismatch;
   }
 
+  int score = 500;
   if (!is_multitouch_device(evdev))
+  {
+    score += 500
+  }
+  else if (!is_singletouch_device(evdev))
   {
     goto mismatch;
   }
-
-  int score = 1000;
 
   if (libevdev_has_event_code(evdev, EV_ABS, ABS_MT_TOOL_TYPE))
   {

--- a/jni/minitouch/minitouch.c
+++ b/jni/minitouch/minitouch.c
@@ -135,9 +135,9 @@ static int consider_device(const char* devpath, internal_state_t* state)
   }
 
   int score = 500;
-  if (!is_multitouch_device(evdev))
+  if (is_multitouch_device(evdev))
   {
-    score += 500
+    score += 500;
   }
   else if (!is_singletouch_device(evdev))
   {


### PR DESCRIPTION
Some emulators do not have files supporting multitouch but single touch to emulate events. To support it the scoring was adapted to consider input files having that capability but still giving moultitouch the preference. Most important are two changes:
1. State contains the event code attributes used to send the touch events depending on the property of the device.
1. The function set_abs_configuration sets some information such as screen resolution and event code used for touches.