### PR TITLE
Added STDIN and File Input

### DIFF
--- a/jni/minitouch/minitouch.c
+++ b/jni/minitouch/minitouch.c
@@ -22,12 +22,12 @@ static int g_verbose = 0;
 static void usage(const char* pname)
 {
   fprintf(stderr,
-    "Usage: %s [-h] [-d <device>] [-n <name>]\n"
+    "Usage: %s [-h] [-d <device>] [-n <name>] [-v] [-i] [-f <file>]\n"
     "  -d <device>: Use the given touch device. Otherwise autodetect.\n"
     "  -n <name>:   Change the name of of the abtract unix domain socket. (%s)\n"
     "  -v:          Verbose output.\n"
-    "  -i:          Use STDIN and doesn't start socket.\n"
-    "  -f <file>:   Runs a file with a list of commands, doesn't start socket."
+    "  -i:          Uses STDIN and doesn't start socket.\n"
+    "  -f <file>:   Runs a file with a list of commands, doesn't start socket.\n"
     "  -h:          Show help.\n",
     pname, DEFAULT_SOCKET_NAME
   );

--- a/jni/minitouch/minitouch.c
+++ b/jni/minitouch/minitouch.c
@@ -589,7 +589,7 @@ static int start_server(char* sockname)
   strncpy(&addr.sun_path[1], sockname, strlen(sockname));
 
   if (bind(fd, (struct sockaddr*) &addr,
-           sizeof(sa_family_t) + strlen(sockname) + 1) < 0)
+    sizeof(sa_family_t) + strlen(sockname) + 1) < 0)
   {
     perror("binding socket");
     close(fd);


### PR DESCRIPTION
I wanted the ability to be able to run minitouch as a standalone program, so I added the ability to accept from STDIN or a separate file.  I also modified the socket handling itself to wrap the `fd` in a `FILE*` stream, so I was able to use standardized functions for all input modes. 

Compile worked for all platforms, tested on armeabi-v7a/no-pie without problems

### Example usage 
```bash
adb shell "echo -e 'd 0 10 10 50\nc\nw 2500\nu 0\nc' | /data/local/tmp/minitouch -i -v"  # STDIN pipe

adb shell "/data/local/tmp/minitouch -i -v"                                              # Terminal input

adb shell "echo -e 'd 0 10 10 50\nc\nw 2500\nu 0\nc' > /data/local/tmp/file.in"
adb shell "/data/local/tmp/minitouch -f /data/local/tmp/file.in -v"                      # File input
```